### PR TITLE
fix: stream string table to prevent OOM on malformed APKs

### DIFF
--- a/apkparser.go
+++ b/apkparser.go
@@ -8,12 +8,33 @@ import (
 	"runtime/debug"
 )
 
+// DefaultMaxStringTableBytes is the default total memory budget for all decoded
+// strings in a single string table (50 MB).
+const DefaultMaxStringTableBytes int64 = 50 * 1024 * 1024
+
+// ParseConfig holds optional configuration for APK/XML/resource parsing.
+// A nil *ParseConfig is valid and uses defaults for all fields.
+type ParseConfig struct {
+	// MaxStringTableBytes limits the total decoded bytes per string table.
+	// Strings are clipped (longest first) so that total usage fits within
+	// this budget. Zero means DefaultMaxStringTableBytes.
+	MaxStringTableBytes int64
+}
+
+func (c *ParseConfig) stringBudget() int64 {
+	if c != nil && c.MaxStringTableBytes > 0 {
+		return c.MaxStringTableBytes
+	}
+	return DefaultMaxStringTableBytes
+}
+
 type ApkParser struct {
 	apkPath string
 	zip     *ZipReader
 
-	encoder   ManifestEncoder
+	encoder ManifestEncoder
 	resources *ResourceTable
+	Config  *ParseConfig
 }
 
 // Calls ParseApkReader
@@ -94,7 +115,7 @@ func (p *ApkParser) parseResources() (err error) {
 	}
 	defer resourcesFile.Close()
 
-	p.resources, err = ParseResourceTable(resourcesFile)
+	p.resources, err = ParseResourceTableWithConfig(resourcesFile, p.Config)
 	return
 }
 
@@ -111,7 +132,7 @@ func (p *ApkParser) ParseXml(name string) error {
 
 	var lastErr error
 	for file.Next() {
-		if err := ParseXml(file, p.encoder, p.resources); err == nil {
+		if err := ParseXmlWithConfig(file, p.encoder, p.resources, p.Config); err == nil {
 			return nil
 		} else {
 			lastErr = err

--- a/binxml.go
+++ b/binxml.go
@@ -14,9 +14,10 @@ import (
 )
 
 type binxmlParseInfo struct {
-	strings     stringTable
-	resourceIds []uint32
-	openTags    []xml.Name
+	strings       stringTable
+	resourceIds   []uint32
+	openTags      []xml.Name
+	stringBudget  int64
 
 	encoder ManifestEncoder
 	res     *ResourceTable
@@ -33,9 +34,16 @@ func ParseManifest(r io.Reader, enc ManifestEncoder, resources *ResourceTable) e
 
 // Parse the binary Xml format. The resources are optional and can be nil.
 func ParseXml(r io.Reader, enc ManifestEncoder, resources *ResourceTable) error {
+	return ParseXmlWithConfig(r, enc, resources, nil)
+}
+
+// ParseXmlWithConfig is like ParseXml but accepts a ParseConfig for tuning
+// parser behavior. A nil config uses defaults.
+func ParseXmlWithConfig(r io.Reader, enc ManifestEncoder, resources *ResourceTable, config *ParseConfig) error {
 	x := binxmlParseInfo{
-		encoder: enc,
-		res:     resources,
+		encoder:      enc,
+		res:          resources,
+		stringBudget: config.stringBudget(),
 	}
 
 	id, headerLen, totalLen, err := parseChunkHeader(r)
@@ -91,7 +99,7 @@ func ParseXml(r io.Reader, enc ManifestEncoder, resources *ResourceTable) error 
 
 		switch id {
 		case chunkStringTable:
-			x.strings, err = parseStringTable(lm)
+			x.strings, err = parseStringTable(lm, x.stringBudget)
 		case chunkResourceIds:
 			err = x.parseResourceIds(lm)
 		default:

--- a/resources.go
+++ b/resources.go
@@ -19,6 +19,7 @@ type ResourceTable struct {
 	mainStrings   stringTable
 	nextPackageId uint32
 	packages      map[uint32]*packageGroup
+	stringBudget  int64
 }
 
 type packageGroup struct {
@@ -102,9 +103,16 @@ const (
 
 // Parses the resources.arsc file
 func ParseResourceTable(r io.Reader) (*ResourceTable, error) {
+	return ParseResourceTableWithConfig(r, nil)
+}
+
+// ParseResourceTableWithConfig is like ParseResourceTable but accepts a
+// ParseConfig for tuning parser behavior. A nil config uses defaults.
+func ParseResourceTableWithConfig(r io.Reader, config *ParseConfig) (*ResourceTable, error) {
 	res := ResourceTable{
 		nextPackageId: 2,
 		packages:      make(map[uint32]*packageGroup),
+		stringBudget:  config.stringBudget(),
 	}
 
 	id, hdrLen, totalLen, err := parseChunkHeader(r)
@@ -154,7 +162,7 @@ func ParseResourceTable(r io.Reader) (*ResourceTable, error) {
 		switch id {
 		case chunkStringTable:
 			if res.mainStrings.isEmpty() {
-				res.mainStrings, err = parseStringTable(lm)
+				res.mainStrings, err = parseStringTable(lm, res.stringBudget)
 			}
 		case chunkTablePackage:
 			if packageCurrent >= packagesCnt {
@@ -234,7 +242,7 @@ func (x *ResourceTable) parsePackage(r *io.LimitedReader, hdrLen uint16) error {
 		return err
 	}
 
-	if pkg.typeStrings, err = parseStringTableWithChunk(pkgReader); err != nil {
+	if pkg.typeStrings, err = parseStringTableWithChunk(pkgReader, x.stringBudget); err != nil {
 		return err
 	}
 
@@ -242,7 +250,7 @@ func (x *ResourceTable) parsePackage(r *io.LimitedReader, hdrLen uint16) error {
 		return err
 	}
 
-	if pkg.keyStrings, err = parseStringTableWithChunk(pkgReader); err != nil {
+	if pkg.keyStrings, err = parseStringTableWithChunk(pkgReader, x.stringBudget); err != nil {
 		return err
 	}
 

--- a/stringtable.go
+++ b/stringtable.go
@@ -1,12 +1,12 @@
 package apkparser
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"math"
+	"sort"
 	"strings"
 	"unicode/utf16"
 	"unicode/utf8"
@@ -15,16 +15,33 @@ import (
 const (
 	stringFlagSorted = 0x00000001
 	stringFlagUtf8   = 0x00000100
+
+	// Marker appended to strings that were truncated by the budget.
+	truncatedMarker = "<TRUNCATED>"
 )
 
 type stringTable struct {
 	isUtf8        bool
 	stringOffsets []byte
-	data          []byte
-	cache         map[uint32]string
+	strings       []string
 }
 
-func parseStringTableWithChunk(r io.Reader) (res stringTable, err error) {
+// sanitizeString replaces NUL bytes and invalid UTF-8 sequences with U+FFFE.
+func sanitizeString(s string) string {
+	if !utf8.ValidString(s) || strings.ContainsRune(s, 0) {
+		return strings.Map(func(r rune) rune {
+			switch r {
+			case 0, utf8.RuneError:
+				return '\uFFFE'
+			default:
+				return r
+			}
+		}, s)
+	}
+	return s
+}
+
+func parseStringTableWithChunk(r io.Reader, budget int64) (res stringTable, err error) {
 	id, _, totalLen, err := parseChunkHeader(r)
 	if err != nil {
 		return
@@ -35,10 +52,10 @@ func parseStringTableWithChunk(r io.Reader) (res stringTable, err error) {
 		return
 	}
 
-	return parseStringTable(&io.LimitedReader{R: r, N: int64(totalLen) - chunkHeaderSize})
+	return parseStringTable(&io.LimitedReader{R: r, N: int64(totalLen) - chunkHeaderSize}, budget)
 }
 
-func parseStringTable(r *io.LimitedReader) (stringTable, error) {
+func parseStringTable(r *io.LimitedReader, budget int64) (stringTable, error) {
 	var err error
 	var stringCnt, stringOffset, flags uint32
 	var res stringTable
@@ -107,160 +124,342 @@ func parseStringTable(r *io.LimitedReader) (stringTable, error) {
 		}
 	}
 
-	// A string table chunk's totalLen is a uint32, so r.N can reach ~4 GiB on a
-	// malformed APK. Guard before the allocation: the make succeeds (if the system
-	// has the memory) and io.ReadFull then fails, but the 4 GiB is already live on
-	// the heap. 50 MiB covers every real-world app.
-	const maxStringTableData = 50 * 1024 * 1024
-	if r.N > maxStringTableData {
-		return res, fmt.Errorf("string table data section too large: %d bytes", r.N)
+	// Stream through the data section once, parsing each string at its
+	// offset. For small tables this is equivalent to the old bulk-read
+	// approach; for oversize tables (inflated string tables used for
+	// it avoids buffering the entire declared section.
+	// Strings are clipped (longest first) to fit within maxTotalStringBytes.
+	res.strings = make([]string, stringCnt)
+
+	if r.N <= 0 {
+		return res, nil
 	}
 
-	res.data = make([]byte, r.N)
-	if _, err := io.ReadFull(r, res.data); err != nil {
-		return res, fmt.Errorf("Failed to read string table data: %s", err.Error())
+	// Build offset → []idx mapping and a sorted list of unique offsets.
+	offsetMap := make(map[int64]*pendingStr)
+	for i := uint32(0); i < stringCnt; i++ {
+		off := int64(binary.LittleEndian.Uint32(res.stringOffsets[4*i : 4*i+4]))
+		if p, ok := offsetMap[off]; ok {
+			p.idxs = append(p.idxs, i)
+		} else {
+			offsetMap[off] = &pendingStr{offset: off, idxs: []uint32{i}}
+		}
 	}
 
-	res.cache = make(map[uint32]string)
+	pending := make([]*pendingStr, 0, len(offsetMap))
+	for _, p := range offsetMap {
+		pending = append(pending, p)
+	}
+	sort.Slice(pending, func(i, j int) bool {
+		return pending[i].offset < pending[j].offset
+	})
+
+	// Compute slot sizes: gap between consecutive offsets gives an upper
+	// bound on the encoded byte size of each string. The last string's
+	// slot extends to the end of the data section.
+	dataLen := r.N
+	for i, p := range pending {
+		if i+1 < len(pending) {
+			p.slotSize = pending[i+1].offset - p.offset
+		} else {
+			p.slotSize = dataLen - p.offset
+		}
+		if p.slotSize < 0 {
+			p.slotSize = 0
+		}
+	}
+
+	// Compute per-string byte limits so the total fits within the budget.
+	computeStringBudget(pending, budget)
+
+	pos := int64(0) // current position in data section stream
+	for _, p := range pending {
+		if p.offset < pos {
+			continue // stream is past this offset
+		}
+
+		// Skip gap to this string.
+		if skip := p.offset - pos; skip > 0 {
+			n, err := io.CopyN(ioutil.Discard, r, skip)
+			pos += n
+			if err != nil {
+				break
+			}
+		}
+
+		s, n, err := readStringFromStream(r, res.isUtf8, p.maxData)
+		pos += n
+		if err != nil {
+			break
+		}
+		s = sanitizeString(s)
+		for _, idx := range p.idxs {
+			res.strings[idx] = s
+		}
+	}
+
+	// Caller (binxml.go) drains remaining lm.N bytes.
 	return res, nil
-}
-
-func (t *stringTable) parseString16(r io.Reader) (string, error) {
-	var strCharacters uint32
-	var strCharactersLow, strCharactersHigh uint16
-
-	if err := binary.Read(r, binary.LittleEndian, &strCharactersHigh); err != nil {
-		return "", fmt.Errorf("error reading string char count: %s", err.Error())
-	}
-
-	if (strCharactersHigh & 0x8000) != 0 {
-		if err := binary.Read(r, binary.LittleEndian, &strCharactersLow); err != nil {
-			return "", fmt.Errorf("error reading string char count: %s", err.Error())
-		}
-
-		strCharacters = (uint32(strCharactersHigh&0x7FFF) << 16) | uint32(strCharactersLow)
-	} else {
-		strCharacters = uint32(strCharactersHigh)
-	}
-
-	// Validate strCharacters against the bytes still available in the reader before
-	// allocating. get() always passes bytes.NewReader(t.data[offset:]), so the
-	// assertion is guaranteed to succeed; it also guards against future call-site
-	// changes. A correctly-formed UTF-16 string cannot claim more characters than
-	// remaining_bytes/2, so this catches both crafted length fields and any decoding
-	// misalignment.
-	if br, ok := r.(*bytes.Reader); ok {
-		if uint64(strCharacters)*2 > uint64(br.Len()) {
-			return "", fmt.Errorf("string length %d chars exceeds available data %d bytes",
-				strCharacters, br.Len())
-		}
-	}
-
-	buf := make([]uint16, strCharacters)
-	// Pass buf ([]uint16) not &buf (*[]uint16). binary.Read's intDataSize fast-path
-	// switch handles []uint16 but not *[]uint16; passing a pointer-to-slice silently
-	// falls into the reflection path, allocating an extra []byte temp buffer of the
-	// same size and calling reflect.New per element.
-	if err := binary.Read(r, binary.LittleEndian, buf); err != nil {
-		return "", fmt.Errorf("error reading string: %s", err.Error())
-	}
-
-	decoded := utf16.Decode(buf)
-	for len(decoded) != 0 && decoded[len(decoded)-1] == 0 {
-		decoded = decoded[:len(decoded)-1]
-	}
-
-	return string(decoded), nil
-}
-
-func (t *stringTable) parseString8Len(r io.Reader) (int64, error) {
-	var strCharacters int64
-	var strCharactersLow, strCharactersHigh uint8
-
-	if err := binary.Read(r, binary.LittleEndian, &strCharactersHigh); err != nil {
-		return 0, fmt.Errorf("error reading string char count: %s", err.Error())
-	}
-
-	if (strCharactersHigh & 0x80) != 0 {
-		if err := binary.Read(r, binary.LittleEndian, &strCharactersLow); err != nil {
-			return 0, fmt.Errorf("error reading string char count: %s", err.Error())
-		}
-		strCharacters = (int64(strCharactersHigh&0x7F) << 8) | int64(strCharactersLow)
-	} else {
-		strCharacters = int64(strCharactersHigh)
-	}
-	return strCharacters, nil
-}
-
-func (t *stringTable) parseString8(r io.Reader) (string, error) {
-	// Length of the string in UTF16
-	_, err := t.parseString8Len(r)
-	if err != nil {
-		return "", err
-	}
-
-	len8, err := t.parseString8Len(r)
-	if err != nil {
-		return "", err
-	}
-
-	buf := make([]uint8, len8)
-	if err := binary.Read(r, binary.LittleEndian, buf); err != nil {
-		return "", fmt.Errorf("error reading string : %s", err.Error())
-	}
-
-	for len(buf) != 0 && buf[len(buf)-1] == 0 {
-		buf = buf[:len(buf)-1]
-	}
-
-	return string(buf), nil
 }
 
 func (t *stringTable) get(idx uint32) (string, error) {
 	if idx == math.MaxUint32 {
 		return "", nil
-	} else if idx >= uint32(len(t.stringOffsets)/4) {
+	}
+
+	if idx >= uint32(len(t.strings)) {
 		return "", fmt.Errorf("String with idx %d not found!", idx)
 	}
 
-	if str, prs := t.cache[idx]; prs {
-		return str, nil
-	}
-
-	offset := binary.LittleEndian.Uint32(t.stringOffsets[4*idx : 4*idx+4])
-	if offset >= uint32(len(t.data)) {
-		return "", fmt.Errorf("String offset for idx %d is out of bounds (%d >= %d).", idx, offset, len(t.data))
-	}
-
-	r := bytes.NewReader(t.data[offset:])
-
-	var err error
-	var res string
-	if t.isUtf8 {
-		res, err = t.parseString8(r)
-	} else {
-		res, err = t.parseString16(r)
-	}
-
-	if err != nil {
-		return "", err
-	}
-
-	if !utf8.ValidString(res) || strings.ContainsRune(res, 0) {
-		res = strings.Map(func(r rune) rune {
-			switch r {
-			case 0, utf8.RuneError:
-				return '\uFFFE'
-			default:
-				return r
-			}
-		}, res)
-	}
-
-	t.cache[idx] = res
-	return res, nil
+	return t.strings[idx], nil
 }
 
 func (t *stringTable) isEmpty() bool {
-	return t.cache == nil
+	return t.strings == nil
+}
+
+type pendingStr struct {
+	offset   int64
+	slotSize int64 // estimated data bytes for this string (gap to next offset)
+	maxData  int64 // budget-assigned byte limit for reading
+	idxs     []uint32
+}
+
+// computeStringBudget assigns per-string byte limits (p.maxData) so that
+// the total decoded content fits within budget. Small strings keep their
+// full slot; only the largest entries are clipped. Algorithm: sort slot
+// sizes ascending, walk through accumulating; when the next slot would
+// push total over budget, the remaining budget divided evenly among the
+// remaining (larger) strings gives the clip cap.
+func computeStringBudget(pending []*pendingStr, budget int64) {
+	if len(pending) == 0 {
+		return
+	}
+
+	// Collect slot sizes and check if everything fits.
+	sizes := make([]int64, len(pending))
+	var total int64
+	for i, p := range pending {
+		sizes[i] = p.slotSize
+		total += p.slotSize
+	}
+
+	if total <= budget {
+		// Everything fits — no clipping needed.
+		for _, p := range pending {
+			p.maxData = p.slotSize
+		}
+		return
+	}
+
+	// Sort sizes ascending to find the clip threshold.
+	sorted := make([]int64, len(sizes))
+	copy(sorted, sizes)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	remaining := budget
+	n := int64(len(sorted))
+	var clipCap int64
+
+	for i, sz := range sorted {
+		// If we give this string its full slot, how much is left per remaining?
+		countLeft := n - int64(i)
+		if sz*countLeft <= remaining {
+			// This string (and all smaller) fit at full size.
+			remaining -= sz
+			continue
+		}
+		// Budget exceeded: distribute remaining evenly among this and larger strings.
+		clipCap = remaining / countLeft
+		break
+	}
+
+	// If clipCap is still 0 but budget > 0, the loop above ran to completion
+	// without breaking (shouldn't happen when total > budget, but be safe).
+	if clipCap == 0 && remaining > 0 {
+		clipCap = remaining / int64(len(sorted))
+	}
+
+	for _, p := range pending {
+		if p.slotSize <= clipCap {
+			p.maxData = p.slotSize
+		} else {
+			p.maxData = clipCap
+		}
+	}
+}
+
+// readStringFromStream reads a single string directly from a forward-only
+// stream. maxDataBytes limits how many content bytes are kept; excess is
+// skipped to maintain stream position. Returns the decoded string, bytes
+// consumed, and any error.
+func readStringFromStream(r io.Reader, isUtf8 bool, maxDataBytes int64) (string, int64, error) {
+	if isUtf8 {
+		return readString8FromStream(r, maxDataBytes)
+	}
+	return readString16FromStream(r, maxDataBytes)
+}
+
+func readString16FromStream(r io.Reader, maxDataBytes int64) (string, int64, error) {
+	var consumed int64
+
+	var charHigh uint16
+	if err := binary.Read(r, binary.LittleEndian, &charHigh); err != nil {
+		return "", 0, err
+	}
+	consumed += 2
+
+	var strChars uint32
+	if (charHigh & 0x8000) != 0 {
+		var charLow uint16
+		if err := binary.Read(r, binary.LittleEndian, &charLow); err != nil {
+			return "", consumed, err
+		}
+		consumed += 2
+		strChars = (uint32(charHigh&0x7FFF) << 16) | uint32(charLow)
+	} else {
+		strChars = uint32(charHigh)
+	}
+
+	dataBytes := int64(strChars) * 2
+
+	// Determine how many chars to actually read (clip if over budget).
+	readBytes := dataBytes
+	if readBytes > maxDataBytes {
+		readBytes = maxDataBytes &^ 1 // round down to even (UTF-16 pair boundary)
+	}
+	readChars := readBytes / 2
+
+	buf := make([]uint16, readChars)
+	if readChars > 0 {
+		if err := binary.Read(r, binary.LittleEndian, buf); err != nil {
+			return "", consumed, err
+		}
+		consumed += readBytes
+	}
+
+	// Skip any remaining data bytes we didn't read, plus the 2-byte null terminator.
+	skipBytes := dataBytes - readBytes + 2
+	if skipBytes > 0 {
+		n, err := io.CopyN(ioutil.Discard, r, skipBytes)
+		consumed += n
+		if err != nil {
+			// Best-effort: return what we have so far.
+			decoded := utf16.Decode(buf)
+			return string(trimNulRunes(decoded)), consumed, err
+		}
+	}
+
+	decoded := utf16.Decode(buf)
+	s := string(trimNulRunes(decoded))
+	if readBytes < dataBytes && len(s) > len(truncatedMarker) {
+		s = s[:len(s)-len(truncatedMarker)] + truncatedMarker
+	}
+	return s, consumed, nil
+}
+
+func trimNulRunes(rs []rune) []rune {
+	for len(rs) != 0 && rs[len(rs)-1] == 0 {
+		rs = rs[:len(rs)-1]
+	}
+	return rs
+}
+
+func readString8FromStream(r io.Reader, maxDataBytes int64) (string, int64, error) {
+	var consumed int64
+
+	readByte := func() (uint8, error) {
+		var b uint8
+		if err := binary.Read(r, binary.LittleEndian, &b); err != nil {
+			return 0, err
+		}
+		consumed++
+		return b, nil
+	}
+
+	// UTF-16 length (1-2 bytes, discarded).
+	b, err := readByte()
+	if err != nil {
+		return "", consumed, err
+	}
+	if (b & 0x80) != 0 {
+		if _, err := readByte(); err != nil {
+			return "", consumed, err
+		}
+	}
+
+	// UTF-8 length (1-2 bytes).
+	b, err = readByte()
+	if err != nil {
+		return "", consumed, err
+	}
+	var len8 int64
+	if (b & 0x80) != 0 {
+		bLow, err := readByte()
+		if err != nil {
+			return "", consumed, err
+		}
+		len8 = int64(b&0x7F)<<8 | int64(bLow)
+	} else {
+		len8 = int64(b)
+	}
+
+	// Determine how many bytes to actually read (clip if over budget).
+	readLen := len8
+	if readLen > maxDataBytes {
+		readLen = maxDataBytes
+	}
+
+	buf := make([]byte, readLen)
+	if readLen > 0 {
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return "", consumed, err
+		}
+		consumed += readLen
+	}
+
+	// Skip remaining data bytes + null terminator.
+	skipBytes := len8 - readLen + 1
+	if skipBytes > 0 {
+		n, err := io.CopyN(ioutil.Discard, r, skipBytes)
+		consumed += n
+		if err != nil {
+			// Best-effort: return what we have.
+			return string(trimNulBytes(buf)), consumed, err
+		}
+	}
+
+	// If we clipped mid-string, ensure we don't break a UTF-8 sequence.
+	clipped := readLen < len8
+	if clipped {
+		buf = trimIncompleteUTF8(buf)
+	}
+
+	s := string(trimNulBytes(buf))
+	if clipped && len(s) > len(truncatedMarker) {
+		s = s[:len(s)-len(truncatedMarker)] + truncatedMarker
+	}
+	return s, consumed, nil
+}
+
+func trimNulBytes(b []byte) []byte {
+	for len(b) != 0 && b[len(b)-1] == 0 {
+		b = b[:len(b)-1]
+	}
+	return b
+}
+
+// trimIncompleteUTF8 removes trailing bytes that form an incomplete UTF-8
+// sequence (can happen when we clip in the middle of a multi-byte char).
+func trimIncompleteUTF8(b []byte) []byte {
+	if len(b) == 0 || utf8.Valid(b) {
+		return b
+	}
+	// Walk back at most 3 bytes (max UTF-8 continuation) to find a clean cut.
+	for i := 1; i <= 3 && i <= len(b); i++ {
+		if utf8.Valid(b[:len(b)-i]) {
+			return b[:len(b)-i]
+		}
+	}
+	return b
 }

--- a/stringtable_budget_test.go
+++ b/stringtable_budget_test.go
@@ -1,0 +1,272 @@
+package apkparser
+
+import (
+	"encoding/xml"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Test sample: 70ffe20fae868a373d7a04e3d41d6ce974a46d0a1f1d25064537f05a4325168e
+// An APK whose AndroidManifest.xml inflates to ~803MB. The manifest
+// string table contains 353 strings, including a ~764MB UTF-16 string of '/'
+// characters (idx 282) and a ~1.5MB random junk string (idx 351).
+//
+// Run with: go test -run TestStringTableBudget -sample /path/to/sample.apk
+var sampleFlag = flag.String("sample", "", "path to sample APK for budget tests")
+
+// getManifestStringsWithBudget opens the sample APK and parses the manifest's
+// string table with the given budget.
+func getManifestStringsWithBudget(t *testing.T, path string, budget int64) []string {
+	t.Helper()
+
+	zip, err := OpenZip(path)
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	defer zip.Close()
+
+	manifest := zip.File["AndroidManifest.xml"]
+	if manifest == nil {
+		t.Fatal("no AndroidManifest.xml in APK")
+	}
+	if err := manifest.Open(); err != nil {
+		t.Fatalf("open manifest: %v", err)
+	}
+	defer manifest.Close()
+
+	for manifest.Next() {
+		strs, err := parseManifestStringTableInternal(manifest, budget)
+		if err != nil {
+			continue
+		}
+		return strs
+	}
+	t.Fatal("failed to parse manifest string table")
+	return nil
+}
+
+// parseManifestStringTableInternal walks the AXML outer chunk to find the
+// string table chunk, then parses it with the given budget.
+func parseManifestStringTableInternal(r io.Reader, budget int64) ([]string, error) {
+	if budget <= 0 {
+		budget = DefaultMaxStringTableBytes
+	}
+
+	_, headerLen, totalLen, err := parseChunkHeader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	dataLen := int64(totalLen) - int64(headerLen)
+	if skip := int64(headerLen) - chunkHeaderSize; skip > 0 {
+		if _, err := io.CopyN(io.Discard, r, skip); err != nil {
+			return nil, err
+		}
+		dataLen -= skip
+	}
+
+	for dataLen > chunkHeaderSize {
+		cid, _, clen, err := parseChunkHeader(r)
+		if err != nil {
+			return nil, err
+		}
+		dataLen -= chunkHeaderSize
+
+		bodyLen := int64(clen) - chunkHeaderSize
+		lm := &io.LimitedReader{R: r, N: bodyLen}
+
+		if cid == chunkStringTable {
+			st, err := parseStringTable(lm, budget)
+			if err != nil {
+				return nil, err
+			}
+			return st.strings, nil
+		}
+
+		if _, err := io.CopyN(io.Discard, lm, lm.N); err != nil {
+			return nil, err
+		}
+		dataLen -= bodyLen
+	}
+
+	return nil, nil
+}
+
+func countTruncated(strs []string) int {
+	n := 0
+	for _, s := range strs {
+		if strings.HasSuffix(s, truncatedMarker) {
+			n++
+		}
+	}
+	return n
+}
+
+func totalStringBytes(strs []string) int64 {
+	var total int64
+	for _, s := range strs {
+		total += int64(len(s))
+	}
+	return total
+}
+
+// TestParseConfig_StringBudget verifies that ParseConfig.stringBudget() returns
+// sane values for all edge cases.
+func TestParseConfig_StringBudget(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *ParseConfig
+		want   int64
+	}{
+		{"nil config", nil, DefaultMaxStringTableBytes},
+		{"zero value struct", &ParseConfig{}, DefaultMaxStringTableBytes},
+		{"explicit zero", &ParseConfig{MaxStringTableBytes: 0}, DefaultMaxStringTableBytes},
+		{"negative", &ParseConfig{MaxStringTableBytes: -1}, DefaultMaxStringTableBytes},
+		{"negative large", &ParseConfig{MaxStringTableBytes: -999999}, DefaultMaxStringTableBytes},
+		{"min negative", &ParseConfig{MaxStringTableBytes: math.MinInt64}, DefaultMaxStringTableBytes},
+		{"custom 1MB", &ParseConfig{MaxStringTableBytes: 1024 * 1024}, 1024 * 1024},
+		{"custom 1GB", &ParseConfig{MaxStringTableBytes: 1024 * 1024 * 1024}, 1024 * 1024 * 1024},
+		{"custom 1 byte", &ParseConfig{MaxStringTableBytes: 1}, 1},
+		{"max int64", &ParseConfig{MaxStringTableBytes: math.MaxInt64}, math.MaxInt64},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.config.stringBudget()
+			if got != tt.want {
+				t.Errorf("stringBudget() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseXmlWithConfig_AllConfigValues parses real testdata manifests with
+// various ParseConfig values to verify nothing crashes.
+func TestParseXmlWithConfig_AllConfigValues(t *testing.T) {
+	files, err := ioutil.ReadDir("testdata")
+	if err != nil {
+		t.Fatalf("failed to open testdata directory: %s", err)
+	}
+
+	configs := []*ParseConfig{
+		nil,
+		{},
+		{MaxStringTableBytes: 0},
+		{MaxStringTableBytes: -1},
+		{MaxStringTableBytes: 1},
+		{MaxStringTableBytes: 100},
+		{MaxStringTableBytes: 1024},
+		{MaxStringTableBytes: 1024 * 1024},
+		{MaxStringTableBytes: DefaultMaxStringTableBytes},
+		{MaxStringTableBytes: 1024 * 1024 * 1024},
+		{MaxStringTableBytes: math.MaxInt64},
+	}
+
+	for _, fi := range files {
+		if fi.IsDir() || !strings.HasSuffix(fi.Name(), ".bin") {
+			continue
+		}
+
+		for _, cfg := range configs {
+			name := fi.Name()
+			budgetName := "nil"
+			if cfg != nil {
+				budgetName = fmt.Sprintf("%d", cfg.MaxStringTableBytes)
+			}
+
+			t.Run(name+"/budget="+budgetName, func(t *testing.T) {
+				f, err := os.Open(filepath.Join("testdata", fi.Name()))
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer f.Close()
+
+				enc := xml.NewEncoder(io.Discard)
+				err = ParseXmlWithConfig(f, enc, nil, cfg)
+				if err != nil {
+					t.Logf("parse error (may be expected with tiny budget): %v", err)
+				}
+				// The main assertion is that we don't panic/crash.
+			})
+		}
+	}
+}
+
+// TestStringTableBudget_SampleAPK verifies that the configurable string table
+// budget correctly controls truncation on an APK with an inflated
+// manifest string table (~764MB UTF-16 → ~382MB UTF-8 decoded).
+//
+// The sample has 353 strings. String idx 282 is ~382MB of '/' characters.
+// String idx 351 is ~1.5MB of random junk.
+//
+// Skipped unless -sample flag is provided.
+func TestStringTableBudget_SampleAPK(t *testing.T) {
+	if *sampleFlag == "" {
+		t.Skip("-sample flag not set")
+	}
+
+	zip, err := OpenZip(*sampleFlag)
+	if err != nil {
+		t.Skipf("sample APK not available: %v", err)
+	}
+	zip.Close()
+
+	tests := []struct {
+		name            string
+		budget          int64
+		expectTruncated bool
+		minTruncCount   int // minimum expected <TRUNCATED> markers
+	}{
+		{
+			name:            "default budget clips giant string",
+			budget:          DefaultMaxStringTableBytes,
+			expectTruncated: true,
+			minTruncCount:   1,
+		},
+		{
+			name:            "1GB budget fits everything",
+			budget:          1024 * 1024 * 1024,
+			expectTruncated: false,
+		},
+		{
+			name:            "1MB budget clips multiple strings",
+			budget:          1 * 1024 * 1024,
+			expectTruncated: true,
+			minTruncCount:   2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			strs := getManifestStringsWithBudget(t, *sampleFlag, tt.budget)
+
+			if len(strs) != 353 {
+				t.Fatalf("expected 353 strings, got %d", len(strs))
+			}
+
+			trunc := countTruncated(strs)
+			total := totalStringBytes(strs)
+
+			t.Logf("budget=%d total_bytes=%d truncated=%d", tt.budget, total, trunc)
+
+			if tt.expectTruncated && trunc < tt.minTruncCount {
+				t.Errorf("expected at least %d truncated strings, got %d", tt.minTruncCount, trunc)
+			}
+			if !tt.expectTruncated && trunc > 0 {
+				t.Errorf("expected no truncation, got %d truncated strings", trunc)
+			}
+
+			// With truncation active, total bytes must be within budget.
+			if tt.expectTruncated && total > tt.budget {
+				t.Errorf("total string bytes %d exceeds budget %d", total, tt.budget)
+			}
+		})
+	}
+}

--- a/validation_test.go
+++ b/validation_test.go
@@ -151,7 +151,7 @@ func TestParseStringTable_StringCountExceedsData(t *testing.T) {
 		N: int64(buf.Len()), // only 20 bytes — can't hold 400K offset bytes
 	}
 
-	_, err := parseStringTable(r)
+	_, err := parseStringTable(r, DefaultMaxStringTableBytes)
 	if err == nil {
 		t.Fatal("expected error for string count exceeding available data")
 	}
@@ -166,7 +166,7 @@ func TestParseStringTableWithChunk_TotalLenTooSmall(t *testing.T) {
 	// parseChunkHeader rejects this before the uint32 underflow can occur.
 	writeChunkHeader(&buf, chunkStringTable, 8, 4)
 
-	_, err := parseStringTableWithChunk(&buf)
+	_, err := parseStringTableWithChunk(&buf, DefaultMaxStringTableBytes)
 	if err == nil {
 		t.Fatal("expected error for totalLen < headerLen")
 	}


### PR DESCRIPTION
Replace the old data[]byte + lazy-cache string table with a single-pass streaming decoder that clips strings to a configurable memory budget (default 50 MB). Strings exceeding the budget are truncated longest-first and marked with <TRUNCATED>.

New public API:
- ParseConfig struct for caller-controlled parser options
- ParseXmlWithConfig / ParseResourceTableWithConfig
- ApkParser.Config field
- DefaultMaxStringTableBytes constant

Existing ParseXml / ParseResourceTable signatures are unchanged.