### PR TITLE
fix: drain leftover bytes in string table, tolerate trailing junk

### DIFF
--- a/binxml.go
+++ b/binxml.go
@@ -84,6 +84,11 @@ func ParseXmlWithConfig(r io.Reader, enc ManifestEncoder, resources *ResourceTab
 
 		id, headerLen, len, err = parseChunkHeader(r)
 		if err != nil {
+			// If we already parsed XML content, treat a bad trailing
+			// chunk header as end-of-document (matches Android behavior).
+			if lastId != 0 {
+				break
+			}
 			return fmt.Errorf("error parsing header at 0x%08x of 0x%08x %08x: %s", pos, dataLen, lastId, err.Error())
 		}
 

--- a/stringtable.go
+++ b/stringtable.go
@@ -198,7 +198,8 @@ func parseStringTable(r *io.LimitedReader, budget int64) (stringTable, error) {
 		}
 	}
 
-	// Caller (binxml.go) drains remaining lm.N bytes.
+	// Drain any remaining bytes so the LimitedReader is fully consumed.
+	io.CopyN(ioutil.Discard, r, r.N)
 	return res, nil
 }
 


### PR DESCRIPTION
Two fixes for APK parsing regressions introduced in #7:

- String table drain: parseStringTable may not consume the entire data section when budget-clipping large strings or when trailing padding exists. The LimitedReader now drains remaining bytes before returning, so callers (especially resources.go which checks lm.N != 0) don't see leftover bytes as an error.

- Trailing junk tolerance: Some APKs have garbage bytes appended after the last valid XML chunk. If at least one chunk was already successfully parsed, a malformed trailing chunk header is now treated as end-of-document instead of a fatal error. This matches Android's ResXMLParser behavior.

Samples: c30c2c45e1eb08c9fba57a7ec8bbca92f3f51cebf8d0c33f7b775c40dd327e3e, dacaf10c59f6ee607b9b9eae339b3b8c5371b29f36de0c0558c7a91d1cd934cf